### PR TITLE
Updated Web Server Counts for 7.0 TechnologyType change

### DIFF
--- a/META-INF/MANIFEST.MF
+++ b/META-INF/MANIFEST.MF
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 Bundle-SymbolicName: com.dynatrace.license.count;singleton:=true
-Bundle-Version: 2.0.2
+Bundle-Version: 2.0.3
 Bundle-Name: License Count
 Bundle-ClassPath: .,lib/commons-codec-1.4.jar,lib/commons-logging-1.1.
  1.jar,lib/httpclient-4.1.2.jar,lib/httpcore-4.1.2.jar

--- a/src/com/dynatrace/license/count/monitor/counter.java
+++ b/src/com/dynatrace/license/count/monitor/counter.java
@@ -822,16 +822,15 @@ public class counter implements Monitor {
 					case "java":								
 						java++;
 						break;
-					case "web server":
+                    case "iis":
 						web++;
-						if (element.getElementsByTagName("agentInstanceName").item(0).getTextContent().toLowerCase().contains("[apache")) {
-							web_apache_individual++;
-							web_apacheList.add(allnodes.item(i));
-							}
-						if (element.getElementsByTagName("agentInstanceName").item(0).getTextContent().toLowerCase().contains("[iis")) {
-							web_iis_individual++;
-							web_iisList.add(allnodes.item(i));
-							}
+						web_iis_individual++;
+						web_iisList.add(allnodes.item(i));
+						break;
+                    case "apache":
+						web++;
+						web_apache_individual++;
+						web_apacheList.add(allnodes.item(i));
 						break;
 					case "websphere message broker":
 						mb++;


### PR DESCRIPTION
TechnologyType Definition changed between AppMon 6 and 7 from always being Web Server to the actual Web Server type (IIS or Apache).  

I have not tested this with IHS Web Server - further updates may be needed for this type of Web Server.