### PR TITLE
Replace 6.5 Web Server Capture

### DIFF
--- a/META-INF/MANIFEST.MF
+++ b/META-INF/MANIFEST.MF
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 Bundle-SymbolicName: com.dynatrace.license.count;singleton:=true
-Bundle-Version: 2.0.3
+Bundle-Version: 2.0.4
 Bundle-Name: License Count
 Bundle-ClassPath: .,lib/commons-codec-1.4.jar,lib/commons-logging-1.1.
  1.jar,lib/httpclient-4.1.2.jar,lib/httpcore-4.1.2.jar

--- a/src/com/dynatrace/license/count/monitor/counter.java
+++ b/src/com/dynatrace/license/count/monitor/counter.java
@@ -822,6 +822,19 @@ public class counter implements Monitor {
 					case "java":								
 						java++;
 						break;
+                    //Web Server for 6.5 Support
+                    case "web server":
+						web++;
+						if (element.getElementsByTagName("agentInstanceName").item(0).getTextContent().toLowerCase().contains("[apache")) {
+							web_apache_individual++;
+							web_apacheList.add(allnodes.item(i));
+							}
+						if (element.getElementsByTagName("agentInstanceName").item(0).getTextContent().toLowerCase().contains("[iis")) {
+							web_iis_individual++;
+							web_iisList.add(allnodes.item(i));
+							}
+						break;
+                    //Web Server for 7.0
                     case "iis":
 						web++;
 						web_iis_individual++;


### PR DESCRIPTION
Re-place 6.5 Web Server Capture.  This version will work with 6.5 and 7.0